### PR TITLE
Add typings for event listeners in PandaProviderType.

### DIFF
--- a/src/types/providerTypes.ts
+++ b/src/types/providerTypes.ts
@@ -284,6 +284,14 @@ export type DecryptRequest = {
 
 export type PandaProviderType = {
   isReady: boolean;
+  on: (
+    event: "signedOut" | "networkChanged",
+    listener: (args?: { [key: string]: any }) => void
+  ) => void;
+  removeListener: (
+    event: "signedOut" | "networkChanged",
+    listener: (args?: { [key: string]: any }) => void
+  ) => void;
   connect: () => Promise<string | undefined>;
   disconnect: () => Promise<boolean>;
   isConnected: () => Promise<boolean>;


### PR DESCRIPTION
This pull request adds typings for event listeners in the PandaProviderType interface.

Related to: https://github.com/Panda-Wallet/panda-wallet/issues/176

Please review this pull request along with pull request #205 in the Panda Wallet repository.